### PR TITLE
Update to fix GrowlNotifier which throws some errors only while logging

### DIFF
--- a/client.py
+++ b/client.py
@@ -62,6 +62,8 @@ if __name__ == "__main__":
 	(options,message) = ClientParser().parse_args()
 	if options.debug:
 		logging.basicConfig(level=options.verbose)
+	else:
+		logging.basicConfig(level=logging.ERROR)
 	
 	growl = GrowlNotifier(
 		applicationName = options.app,

--- a/gntp/__init__.py
+++ b/gntp/__init__.py
@@ -2,6 +2,9 @@ import re
 import hashlib
 import time
 import platform
+import logging
+
+logger = logging.getLogger(__name__)
 
 __version__ = '0.4'
 
@@ -202,12 +205,19 @@ class _GNTPBase(object):
 		parts = self.raw.split('\r\n\r\n')
 		self.info = self._parse_info(data)
 		self.headers = self._parse_dict(parts[0])
-	def encode(self):
+	def encode(self, throw_validate_errors=True):
 		'''
 		Encode a GNTP Message
+		@param throw_validate_errors: (Optional) Specifies if validate() errors should be raised
 		@return: GNTP Message ready to be sent
 		'''
-		self.validate()
+		try:
+			self.validate()
+		except ParseError as e:
+			if throw_validate_errors:
+				raise
+			else:
+				logger.warning(e)
 		EOL = u'\r\n'
 		
 		message = self._format_info() + EOL
@@ -286,12 +296,19 @@ class GNTPRegister(_GNTPBase):
 			
 		self.notifications.append(notice)
 		self.add_header('Notifications-Count', len(self.notifications))
-	def encode(self):
+	def encode(self, throw_validate_errors=True):
 		'''
 		Encode a GNTP Registration Message
+		@param throw_validate_errors: (Optional) Specifies if validate() errors should be raised
 		@return: GNTP Registration Message ready to be sent
 		'''
-		self.validate()
+		try:
+			self.validate()
+		except ParseError as e:
+			if throw_validate_errors:
+				raise
+			else:
+				logger.warning(e)
 		EOL = u'\r\n'
 		
 		message = self._format_info() + EOL
@@ -359,12 +376,19 @@ class GNTPNotice(_GNTPBase):
 				notice['Data'] = self._decode_binary(part,notice)
 				#open('notice.png','wblol').write(notice['Data'])
 				self.resources[ notice.get('Identifier') ] = notice
-	def encode(self):
+	def encode(self, throw_validate_errors=True):
 		'''
 		Encode a GNTP Notification Message
+		@param throw_validate_errors: (Optional) Specifies if validate() errors should be raised
 		@return: GNTP Notification Message ready to be sent
 		'''
-		self.validate()
+		try:
+			self.validate()
+		except ParseError as e:
+			if throw_validate_errors:
+				raise
+			else:
+				logger.warning(e)
 		EOL = u'\r\n'
 		
 		message = self._format_info() + EOL

--- a/gntp/notifier.py
+++ b/gntp/notifier.py
@@ -125,6 +125,5 @@ class GrowlNotifier(object):
 		s.send(data.encode('utf8','replace'))
 		response = gntp.parse_gntp(s.recv(1024))
 		s.close()
-		
-		logger.debug('From : %s:%s <%s>\n%s',self.hostname,self.port,response.__class__,response)
+		logger.debug('From : %s:%s <%s>\n%s',self.hostname,self.port,response.__class__,response.encode(throw_validate_errors=False))
 		return response


### PR DESCRIPTION
Rationale is that specifying more debug logging should not cause new exceptions to be raised that aren't encountered when debug logging is not enabled

Added throw_validate_errors option and logging to encode(), so GrowlNotifier.Send() (in notifier.py) does not throw errors while logging debug messages 

However, adding logging in gntp/**init**.py meant that a logging.basicConfig had to always be provided/available, so chose a default of logging.basicConfig(level=logging.ERROR).
