### PR TITLE
Testing fake hash method requires password. Refers #38.

### DIFF
--- a/gntp/test/test_hash.py
+++ b/gntp/test/test_hash.py
@@ -40,4 +40,5 @@ class TestHash(GNTPTestCase):
 
 	def test_fake(self):
 		'''Fake hash should not work'''
+		self.growl.password = 'foobar'
 		self.assertRaises(UnsupportedError, self._hash, 'fake-hash')


### PR DESCRIPTION
Other tests in that module should be probably updated too (they should not rely on .gntp however passing wrong password - or any password on a system that don't expect any- would break them). I would suggest mocking notification send (and leave one integration test so we can actually see any notification being shown by grwol).
